### PR TITLE
domain: rephrase the author validation error

### DIFF
--- a/domain/Author.go
+++ b/domain/Author.go
@@ -9,7 +9,7 @@ type Author struct {
 
 func (a Author) Validate() error {
 	if a.Name == "" {
-		return errors.New("author name must not be nil")
+		return errors.New("author name must not be empty")
 	}
 
 	return nil


### PR DESCRIPTION
As the name field in the author struct is not a pointer, it can never be nil. Thus, stating in the error that the name is empty rather than nil makes more sense.